### PR TITLE
macOS: reliable native Bluetooth printing via pure-Python IOBluetooth (fixes #3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,9 @@ celerybeat.pid
 # SageMath parsed files
 *.sage.py
 
+# macOS
+.DS_Store
+
 # Environments
 .env
 .venv

--- a/label
+++ b/label
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# label — convenience wrapper for printing to a Brother PT-P300BT over the
+# native macOS Bluetooth bridge (see native/README.md).
+#
+# Usage:
+#   label "Hello"                      # one line
+#   label "Top\nBottom"                # two lines (font auto-shrinks to fit)
+#   label -M art.pdf "With an icon"    # merge a PNG/PDF/QR before the text
+#   label -H --stroke-width 2 "Bold"   # any printlabel.py flag passes through
+#   label -n -S /tmp/p.png "Preview"   # save a PNG preview, don't print
+#
+# Environment overrides:
+#   LABEL_PORT  printer target          (default: bt:PT-P300)
+#   LABEL_FONT  font file path          (default: Arial, macOS)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PORT="${LABEL_PORT:-bt:PT-P300}"
+FONT="${LABEL_FONT:-/System/Library/Fonts/Supplemental/Arial.ttf}"
+
+if [ "$#" -eq 0 ]; then
+    cat >&2 <<'USAGE'
+usage: label [printlabel.py options] "TEXT"   (use \n for line breaks)
+
+examples:
+  label "Hello"
+  label "Top\nBottom"
+  label -M icon.pdf "With icon"
+  label -n -S /tmp/preview.png "Preview only"
+
+overrides: LABEL_PORT (default bt:PT-P300), LABEL_FONT (default Arial)
+USAGE
+    exit 1
+fi
+
+# Prefer the project's virtualenv if present.
+PY="$SCRIPT_DIR/.venv/bin/python3"
+[ -x "$PY" ] || PY="python3"
+
+# printlabel.py positionals are: COM_PORT FONT_NAME TEXT...; any -flags passed
+# by the user are parsed wherever they appear, so "$@" can mix flags and text.
+exec "$PY" "$SCRIPT_DIR/printlabel.py" "$PORT" "$FONT" "$@"

--- a/labelmaker.py
+++ b/labelmaker.py
@@ -72,11 +72,24 @@ def configure_printer(ser, raster_lines, tape_dim, compress=True, chaining=False
 def do_print_job(ser, args, data):
     print('=> Querying printer status...')
 
-    reset_printer(ser)
-
-    # Dump status
-    ser.write(ptcbp.serialize_control('get_status'))
-    status = ptstatus.unpack_status(ser.read(32))
+    # The Bluetooth serial link (esp. on macOS) can be idle/half-open on first
+    # access, so a single status read may hang or return nothing. Re-init and
+    # re-read until we get a full 32-byte status reply or run out of attempts.
+    status = None
+    for attempt in range(1, 7):
+        reset_printer(ser)
+        ser.reset_input_buffer()
+        ser.write(ptcbp.serialize_control('get_status'))
+        resp = ser.read(32)
+        if len(resp) == 32:
+            status = ptstatus.unpack_status(resp)
+            break
+        print(f"   ...no status yet (attempt {attempt}/6, got "
+              f"{len(resp)} bytes); retrying...")
+    if status is None:
+        print('** Printer did not respond to status query. Make sure it is '
+              'connected and active in Bluetooth, then try again.')
+        sys.exit(1)
     ptstatus.print_status(status)
 
     if status.err != 0x0000 or status.phase_type != 0x00 or status.phase != 0x0000:
@@ -113,9 +126,11 @@ def do_print_job(ser, args, data):
         # Print and feed
         ser.write(ptcbp.serialize_control('print'))
 
-        # Dump status that the printer returns
-        status = ptstatus.unpack_status(ser.read(32))
-        ptstatus.print_status(status)
+        # Dump status that the printer returns (best-effort; the print has
+        # already been sent, so don't crash if the reply is slow/short).
+        resp = ser.read(32)
+        if len(resp) == 32:
+            ptstatus.print_status(ptstatus.unpack_status(resp))
 
     print("=> All done.")
 

--- a/native/README.md
+++ b/native/README.md
@@ -1,0 +1,49 @@
+# Native macOS Bluetooth transport for the PT-P300BT
+
+On macOS the default `/dev/cu.*` Bluetooth-serial bridge is unreliable for the
+PT-P300BT: opening the port hangs or connects "half-open" (data out, nothing
+back), and after one open/close cycle subsequent opens succeed but silently
+carry no data, hanging forever on "Querying printer status…".
+
+The root cause (diagnosed by @cehbz in Ircama/PT-P300BT#3): pyserial's `close()`
+doesn't drain the macOS run loop, so `bluetoothd` never tears down the RFCOMM
+channel and leaves it half-open. The fix is to talk to the printer over a
+**native IOBluetooth RFCOMM channel** and drain the run loop on close.
+
+This is done **in pure Python via [PyObjC](https://pyobjc.readthedocs.io/)** —
+no Swift, no Xcode, no compile step:
+
+```bash
+pip install pyobjc-framework-IOBluetooth   # already in requirements.txt (macOS only)
+```
+
+## Files
+
+- `btnative.py` — a `serial.Serial`-compatible class (`BTSerial`) that opens an
+  IOBluetooth RFCOMM channel to the printer and exposes
+  `write()/read()/reset_input_buffer()/open()/close()`. `printlabel.py` uses it
+  automatically when the port argument starts with `bt:`. Connect/transfer all
+  happen in-process; `close()` drains the run loop so the channel tears down
+  cleanly (the crux of the reconnect bug).
+- `ptprobe.py` — a standalone diagnostic: connect + query status + print the
+  result. Handy for verifying the link without printing.
+
+## Use
+
+```bash
+# Quick connection/status check:
+python3 native/ptprobe.py PT-P300
+
+# Print (bt:NAME matches the paired device whose Bluetooth name contains NAME;
+# NAME defaults to PT-P300):
+python3 printlabel.py "bt:PT-P300" "/System/Library/Fonts/Supplemental/Arial.ttf" "Hello"
+```
+
+Notes:
+- The phone/other host must not hold the printer — it allows one host at a time.
+- The terminal app may need Bluetooth permission (System Settings → Privacy &
+  Security → Bluetooth).
+- If macOS prompts to "finish setting up this printer" in Printers & Scanners,
+  cancel it — we only need the Bluetooth bond, not a CUPS print queue.
+- On macOS, give a full font path (bare `arial.ttf` won't resolve); e.g.
+  `/System/Library/Fonts/Supplemental/Arial.ttf`.

--- a/native/btnative.py
+++ b/native/btnative.py
@@ -1,0 +1,158 @@
+"""Pure-Python (PyObjC) native Bluetooth transport for the PT-P300BT.
+
+A `serial.Serial`-compatible class that talks to the printer over a macOS
+IOBluetooth RFCOMM channel, entirely in-process — no Swift, no subprocess.
+Requires only:  pip install pyobjc-framework-IOBluetooth
+
+Why this exists: the macOS /dev/cu.* Bluetooth-serial bridge is unreliable for
+this printer (pyserial's close() never drains the macOS run loop, so bluetoothd
+leaves the RFCOMM channel half-open and the next open() hangs). Owning the
+IOBluetooth channel directly — and draining the run loop on close — avoids that.
+"""
+
+import atexit
+import time
+
+import objc
+from Foundation import NSObject, NSDefaultRunLoopMode, NSRunLoop, NSDate
+import IOBluetooth
+
+
+class BTError(Exception):
+    pass
+
+
+def _spin(cond, deadline):
+    """Pump the run loop (delivering IOBluetooth callbacks) until cond() or deadline."""
+    rl = NSRunLoop.currentRunLoop()
+    while not cond() and time.time() < deadline:
+        rl.runMode_beforeDate_(NSDefaultRunLoopMode,
+                               NSDate.dateWithTimeIntervalSinceNow_(0.05))
+
+
+class _Delegate(NSObject):
+    def init(self):
+        self = objc.super(_Delegate, self).init()
+        self.open_done = False
+        self.open_status = -1
+        self.closed = False
+        self.rx = bytearray()
+        return self
+
+    def rfcommChannelOpenComplete_status_(self, channel, status):
+        self.open_status = status
+        self.open_done = True
+
+    def rfcommChannelData_data_length_(self, channel, data, length):
+        # PyObjC bridges (void *data, size_t length) to a buffer object.
+        self.rx += bytes(data[:length])
+
+    def rfcommChannelClosed_(self, channel):
+        self.closed = True
+
+
+class BTSerial:
+    """Minimal serial.Serial stand-in over IOBluetooth RFCOMM."""
+
+    def __init__(self, name="PT-P300", timeout=3.0, open_timeout=15.0):
+        self.name = name
+        self.timeout = timeout
+        self._open_timeout = open_timeout
+        self._device = None
+        self._channel = None
+        self._d = None
+        self.is_open = False
+        self.open()
+        atexit.register(self.close)
+
+    # ----- lifecycle -------------------------------------------------------
+    def open(self):
+        if self.is_open:
+            return
+        paired = IOBluetooth.IOBluetoothDevice.pairedDevices()
+        if not paired:
+            raise BTError("No paired Bluetooth devices (Bluetooth off, or this "
+                          "terminal lacks Bluetooth permission in System Settings "
+                          "> Privacy & Security > Bluetooth).")
+        dev = next((d for d in paired if (d.name() or "").find(self.name) >= 0), None)
+        if dev is None:
+            names = ", ".join(d.name() or "?" for d in paired)
+            raise BTError(f'No paired device whose name contains "{self.name}". '
+                          f"Paired: {names}")
+        self._device = dev
+
+        channel_id = self._resolve_channel(dev)
+        self._d = _Delegate.alloc().init()
+        res, channel = dev.openRFCOMMChannelAsync_withChannelID_delegate_(
+            None, channel_id, self._d)
+        if res != 0:
+            raise BTError(f"openRFCOMMChannelAsync failed: {res:#x}")
+        _spin(lambda: self._d.open_done, time.time() + self._open_timeout)
+        if not self._d.open_done or self._d.open_status != 0 or channel is None:
+            raise BTError(f"RFCOMM open failed (status={self._d.open_status}); "
+                          "the link did not come up.")
+        self._channel = channel
+        self.is_open = True
+
+    @staticmethod
+    def _resolve_channel(dev):
+        spp = IOBluetooth.IOBluetoothSDPUUID.uuid16_(0x1101)  # Serial Port Profile
+        rec = dev.getServiceRecordForUUID_(spp)
+        if rec is None:
+            dev.performSDPQuery_(None)
+            _spin(lambda: dev.getServiceRecordForUUID_(spp) is not None,
+                  time.time() + 6)
+            rec = dev.getServiceRecordForUUID_(spp)
+        if rec is not None:
+            res, cid = rec.getRFCOMMChannelID_(None)
+            if res == 0 and cid:
+                return cid
+        return 1  # SPP channel fallback
+
+    def close(self):
+        if self._channel is not None and self.is_open:
+            try:
+                self._channel.closeChannel()
+            except Exception:
+                pass
+            # Drain the run loop so bluetoothd tears down the RFCOMM channel
+            # (the crux of the macOS reconnect bug).
+            _spin(lambda: self._d.closed, time.time() + 1.0)
+        self.is_open = False
+        self._channel = None
+
+    # ----- pyserial-compatible I/O -----------------------------------------
+    def write(self, data):
+        if not self.is_open:
+            raise BTError("port not open")
+        data = bytes(data)
+        mtu = int(self._channel.getMTU()) or 320
+        for i in range(0, len(data), mtu):
+            seg = data[i:i + mtu]
+            self._channel.writeSync_length_(seg, len(seg))
+        return len(data)
+
+    def read(self, n=1):
+        if not self.is_open:
+            raise BTError("port not open")
+        _spin(lambda: len(self._d.rx) >= n, time.time() + self.timeout)
+        take = min(len(self._d.rx), n)
+        out = bytes(self._d.rx[:take])
+        del self._d.rx[:take]
+        return out
+
+    def reset_input_buffer(self):
+        if self._d is not None:
+            del self._d.rx[:]
+
+    def reset_output_buffer(self):
+        pass
+
+    def flush(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        self.close()

--- a/native/ptprobe.py
+++ b/native/ptprobe.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Pure-Python (PyObjC) IOBluetooth RFCOMM probe for the PT-P300BT.
+
+Proves the native-Bluetooth approach works from Python with no Swift/Xcode:
+    pip install pyobjc-framework-IOBluetooth
+
+Finds the paired printer, opens an RFCOMM channel via IOBluetooth, sends a
+status query, prints the 32-byte reply. Mirrors native/ptprobe.swift.
+"""
+import sys
+import time
+
+import objc
+from Foundation import NSObject, NSDefaultRunLoopMode, NSRunLoop, NSDate
+import IOBluetooth
+
+NAME = sys.argv[1] if len(sys.argv) > 1 else "PT-P300"
+TIMEOUT = 10.0
+
+
+def spin(cond, deadline):
+    """Pump the run loop (servicing IOBluetooth callbacks) until cond() or deadline."""
+    rl = NSRunLoop.currentRunLoop()
+    while not cond() and time.time() < deadline:
+        rl.runMode_beforeDate_(NSDefaultRunLoopMode,
+                               NSDate.dateWithTimeIntervalSinceNow_(0.05))
+
+
+class Delegate(NSObject):
+    def init(self):
+        self = objc.super(Delegate, self).init()
+        self.open_done = False
+        self.open_status = -1
+        self.rx = bytearray()
+        return self
+
+    def rfcommChannelOpenComplete_status_(self, channel, status):
+        self.open_status = status
+        self.open_done = True
+
+    def rfcommChannelData_data_length_(self, channel, data, length):
+        # PyObjC bridges (void *data, size_t length) to a bytes-like buffer.
+        self.rx += bytes(data[:length]) if not isinstance(data, (bytes, bytearray)) else bytes(data[:length])
+
+    def rfcommChannelClosed_(self, channel):
+        pass
+
+
+def main():
+    t0 = time.time()
+    paired = IOBluetooth.IOBluetoothDevice.pairedDevices()
+    if not paired:
+        print("** No paired devices (Bluetooth off or no permission).", file=sys.stderr)
+        return 2
+    printer = next((d for d in paired if (d.name() or "").find(NAME) >= 0), None)
+    if printer is None:
+        names = ", ".join(d.name() or "?" for d in paired)
+        print(f'** No paired device matching "{NAME}". Paired: {names}', file=sys.stderr)
+        return 3
+    print(f"Device: {printer.name()}  addr={printer.addressString()}  "
+          f"connected={bool(printer.isConnected())}", file=sys.stderr)
+
+    # Resolve the SPP (Serial Port Profile, UUID 0x1101) RFCOMM channel via SDP.
+    spp = IOBluetooth.IOBluetoothSDPUUID.uuid16_(0x1101)
+    channel_id = 0
+    rec = printer.getServiceRecordForUUID_(spp)
+    if rec is None:
+        printer.performSDPQuery_(None)
+        spin(lambda: printer.getServiceRecordForUUID_(spp) is not None,
+             time.time() + 6)
+        rec = printer.getServiceRecordForUUID_(spp)
+    if rec is not None:
+        res, cid = rec.getRFCOMMChannelID_(None)
+        if res == 0 and cid:
+            channel_id = cid
+    if channel_id == 0:
+        channel_id = 1
+    print(f"SDP: SPP RFCOMM channel = {channel_id}", file=sys.stderr)
+
+    delegate = Delegate.alloc().init()
+    res, channel = printer.openRFCOMMChannelAsync_withChannelID_delegate_(
+        None, channel_id, delegate)
+    if res != 0:
+        print(f"** openRFCOMMChannelAsync failed: {res:#x}", file=sys.stderr)
+        return 4
+    spin(lambda: delegate.open_done, time.time() + TIMEOUT)
+    if not delegate.open_done or delegate.open_status != 0 or channel is None:
+        print(f"** RFCOMM open failed (status={delegate.open_status}).", file=sys.stderr)
+        return 5
+    print(f"RFCOMM open OK in {time.time()-t0:.2f}s (mtu={channel.getMTU()})",
+          file=sys.stderr)
+
+    # Send flush + reset + get_status (ESC i S), then await the 32-byte reply.
+    for payload in (b"\x00" * 64, b"\x1b\x40", b"\x1b\x69\x53"):
+        channel.writeSync_length_(payload, len(payload))
+    t_send = time.time()
+    spin(lambda: len(delegate.rx) >= 32, time.time() + TIMEOUT)
+    channel.closeChannel()
+
+    if len(delegate.rx) >= 32:
+        status = bytes(delegate.rx[:32])
+        err = status[8] | (status[9] << 8)
+        print(f"STATUS OK: 32 bytes in {time.time()-t_send:.2f}s after query",
+              file=sys.stderr)
+        print(f"  model=0x{status[4]:02x}  errors={'none' if err == 0 else hex(err)}"
+              f"  tape_width={status[10]}mm", file=sys.stderr)
+        print(status.hex())
+        return 0
+    print(f"** No status reply (got {len(delegate.rx)} bytes).", file=sys.stderr)
+    return 6
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/printlabel.py
+++ b/printlabel.py
@@ -99,6 +99,13 @@ def set_args():
         default = 12
     )
     p.add_argument(
+        '--merge-gap',
+        metavar='DOTS',
+        type=int,
+        help='Horizontal gap (in dots) between a merged image and the text.',
+        default = 0
+    )
+    p.add_argument(
         '-S', '--save',
         metavar='FILE_NAME',
         help='Save the produced image to a PNG file.'
@@ -346,8 +353,17 @@ def draw_multiline_text(
 def main():
     p = set_args()
     args = p.parse_args()
-    if args.comport not in [p.device for p in list_ports.comports()]:
-        print("Port '" + args.comport + "' does not seem a valid serial communication port.")        
+    if not args.comport.startswith("bt:") and \
+            args.comport not in [p.device for p in list_ports.comports()]:
+        print("Port '" + args.comport + "' does not seem a valid serial communication port.")
+    # Legacy -i/--image: print the given image as the whole label, ignoring text
+    # and font. The image-building code below only ever ran in the non-legacy
+    # branch, so -i used to leave `data` unset and crash; route it through the
+    # (working) merge path with empty text instead.
+    if args.image is not None:
+        args.merge = [args.image] + (args.merge or [])
+        args.text_to_print = []
+        args.image = None
     data = None
     if args.image is None: # not using the legacy mode
         height_of_the_printable_area = 64  # px: number of vertical pixels of the PT-P300BT printer (9 mm)
@@ -601,13 +617,14 @@ def main():
                 )
                 if not loaded_image:
                     p.error(f'Invalid image "{i}"')
+                gap = args.merge_gap if image.width else 0
                 dst = Image.new(
                     "RGB",
-                    (loaded_image.width + image.width, height_of_the_image),
+                    (loaded_image.width + gap + image.width, height_of_the_image),
                     "white"
                 )
                 dst.paste(loaded_image, (args.x_merge, args.y_merge))
-                dst.paste(image, (loaded_image.width, 0))
+                dst.paste(image, (loaded_image.width + gap, 0))
                 image = dst
             # Convert the image to binary
             draw = ImageDraw.Draw(image)
@@ -738,31 +755,42 @@ def main():
         # Check max tape length
         if print_length > 499:
             print("Print length exceeding 49.9 cm = 19.6 in")
-            quit()
+            sys.exit()
 
         # Image save and show
         if args.save:
             print(f'Saving image "{args.save}".')
             image.save(args.save)
             if args.no_print:
-                quit()
+                sys.exit()
         if args.show:
             try:
                 image.show()
             except Exception as e:
                 p.error("Cannot show image:" + repr(e))
             if not args.show_conv and args.no_print:
-                quit()
+                sys.exit()
         if args.show_conv:
             padded.show()
             if args.no_print:
-                quit()
+                sys.exit()
 
         data = padded.tobytes()
 
     # Similar to main() in labelmaker.py
     try:
-        ser = serial.Serial(args.comport)
+        if args.comport.startswith("bt:"):
+            # Native macOS IOBluetooth RFCOMM transport (pure Python via PyObjC).
+            # The /dev/cu.* Bluetooth-serial bridge is unreliable for this printer
+            # (pyserial's close() doesn't drain the macOS run loop, so the RFCOMM
+            # channel is left half-open and the next open() hangs). "bt:NAME"
+            # matches the paired device whose name contains NAME (default PT-P300).
+            sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "native"))
+            from btnative import BTSerial
+            name = args.comport[3:] or "PT-P300"
+            ser = BTSerial(name=name, timeout=3)
+        else:
+            ser = serial.Serial(args.comport, timeout=3)
     except serial.SerialException:
         p.error(
             'Printer on Bluetooth serial port "'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ pyserial
 pillow
 packbits
 pdf2image
+# macOS only: native IOBluetooth transport for reliable Bluetooth printing
+# (the /dev/cu.* serial bridge is unreliable for the PT-P300BT). Enables "bt:".
+pyobjc-framework-IOBluetooth ; sys_platform == "darwin"


### PR DESCRIPTION
## Summary

This makes Bluetooth printing work reliably on macOS, and throws in a few small
fixes along the way. Resolves #3.

## The problem (#3)

On macOS, driving the printer through the `/dev/cu.*` Bluetooth-serial bridge with
pyserial is unreliable: `open()` hangs or connects "half-open" (data goes out, nothing
comes back), and after one open/close cycle every subsequent `open()` *appears* to
succeed but carries no data — hanging forever on `=> Querying printer status...`.
Several people in #3 hit this and gave up (one switched to Windows).

## Root cause

Credit to @cehbz, who pinned this down in #3: pyserial's `close()` doesn't drain the
macOS run loop, so `bluetoothd` never tears down the RFCOMM channel and leaves it
half-open. The next `open()` then connects to a dead channel.

## The fix

Talk to the printer over a **native IOBluetooth RFCOMM channel** instead of the
`/dev/cu.*` bridge, and **drain the run loop on close** so the channel tears down
cleanly. It's implemented in **pure Python via PyObjC** — no Xcode, no Swift, no
compile step, just one `pip install` (macOS only).

Usage: pass a port of the form `bt:NAME`, which matches the paired device whose
Bluetooth name contains `NAME` (default `PT-P300`):

```bash
python3 printlabel.py "bt:PT-P300" "/System/Library/Fonts/Supplemental/Arial.ttf" "Hello"
```

On other platforms nothing changes — a normal serial port works exactly as before,
and the new dependency only installs on macOS.

## What's included

- `native/btnative.py` — `serial.Serial`-compatible `BTSerial` over IOBluetooth RFCOMM
  (in-process; drains the run loop on `close()`)
- `native/ptprobe.py` — standalone connect + status diagnostic
- `printlabel.py` — `bt:NAME` selects the native transport
- `requirements.txt` — `pyobjc-framework-IOBluetooth ; sys_platform == "darwin"`
- `label` — small convenience wrapper (`label "text"`, `label -M art.pdf "text"`, …)

### Drive-by fixes (happy to split these out if you'd prefer)

- **Fixes #12** — `quit()` → `sys.exit()`. `quit()` is only defined when the `site`
  module is loaded, so it crashes the frozen `.exe` (e.g. `-n -c`).
- **`-i`/`--image` was unimplemented** — the image-building code only ran in the
  non-legacy branch, so `-i` left `data` unset and raised `AssertionError`. Routed it
  through the existing merge path so it prints the image as the whole label.
- **`--merge-gap DOTS`** — adds horizontal space between a merged image and the text
  (e.g. an icon/portrait next to a name).

## Testing

On a PT-P300BT (12 mm tape) on macOS: repeated connects from an idle state (RFCOMM
open ~3 s, valid status ~0.4 s every time), and real labels printed — plain text,
multi-line, PDF-merged icon, and an image-only label via the fixed `-i`.

### Windows / Linux unaffected

The native transport only activates for a `bt:` port, and its IOBluetooth import
lives **inside** that branch — a normal serial/COM port never touches it. The new
dependency is gated to macOS via the `; sys_platform == "darwin"` marker.

Verified on a Windows 11 VM (Python 3.13): `pip install -r requirements.txt` reports
`Ignoring pyobjc-framework-IOBluetooth: markers 'sys_platform == "darwin"' don't
match your environment` and installs only the existing deps, and `printlabel.py`
renders labels normally (plain text and the fixed `-i`) with no macOS code path
reached. The only behavioural change on the shared path is a read timeout + status
retry in `do_print_job`, which is a no-op for a healthy connection (status arrives
on the first attempt) and just prevents the previous indefinite hang otherwise.

## Notes

- macOS may need the terminal granted Bluetooth permission (System Settings → Privacy
  & Security → Bluetooth).
- If macOS offers to "finish setting up this printer" in Printers & Scanners, that's a
  CUPS print-queue prompt and can be dismissed — only the Bluetooth bond is needed.
